### PR TITLE
feat: usc-m-r1, filter duration based

### DIFF
--- a/.changeset/wild-poets-heal.md
+++ b/.changeset/wild-poets-heal.md
@@ -1,0 +1,5 @@
+---
+"@metalizzsas/nuster-turbine-machines": patch
+---
+
+fix: USCleaner M R1 now uses Duration instead of a sensor based filter duration

--- a/libs/turbine-machines/src/data/uscleaner-m-1/specs.json
+++ b/libs/turbine-machines/src/data/uscleaner-m-1/specs.json
@@ -160,11 +160,8 @@
     "maintenance": [
         {
             "name": "usc-filter",
-            "durationType": "sensor",
-            "sensorBaseValue": 0.14,
-            "sensorLimitValue": 0.10,
-            "sensorGate": "pump#pressure",
-            "requireEnableGate": "pump#enable"
+            "durationType": "duration",
+            "durationLimit": 15
         }
     ],
     "cyclePremades": [
@@ -289,16 +286,6 @@
                         "plus": ["temperature#heater"],
                         "minus": ["temperature#ventilation"]
                     }]
-                },
-                {
-                    "path": "maintenance.0.sensorBaseValue",
-                    "mode": "set",
-                    "content": 0.20
-                },
-                {
-                    "path": "maintenance.0.sensorLimitValue",
-                    "mode": "set",
-                    "content": 0.12
                 }
             ]
         }


### PR DESCRIPTION
This pull request includes:
- USCleaner M R1: Now using Time duration (15 hours) instead of sensor bases maintenance duration for *filter*