### PR TITLE
chore: rollback to node 18

### DIFF
--- a/.changeset/eleven-terms-drum.md
+++ b/.changeset/eleven-terms-drum.md
@@ -1,0 +1,6 @@
+---
+"@nuster/simulation-server": patch
+"@nuster/turbine": patch
+---
+
+chore(deps): updated enip-ts to 2.0.0

--- a/.github/workflows/ci-docker.yaml
+++ b/.github/workflows/ci-docker.yaml
@@ -1,0 +1,43 @@
+name: 🐳 CI Docker build
+
+on:
+  pull_request:
+
+jobs:
+  build:
+    name: Build and push docker images
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        packages: ["turbine", "ui", "simulation-ui", "simulation-server"]
+    steps:
+      - name: 📚 Checkout repository
+        uses: actions/checkout@v3
+
+      - name: ⛏️ Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      
+      - name: ⛏️ Setup Docker
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: network=host
+
+      - name: 📦 Cache Docker layers
+        uses: actions/cache@v4
+        with:
+          path: /tmp/.buildx-cache
+          key: ${{ runner.os }}-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-buildx-
+        
+      - name: 🧱 Build Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: ./packages/${{ matrix.packages }}
+          file: ./packages/${{ matrix.packages }}/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: false
+          tags: | 
+            nusterkit/${{ matrix.packages }}:draft
+          cache-from: type=local,src=/tmp/.buildx-cache
+          cache-to: type=local,dest=/tmp/.buildx-cache

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: ⛏️ Setup node
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: '20.x'
+          node-version: '18.x'
           cache: 'pnpm'
 
       - name: 🗂️ Install packages 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,7 +34,7 @@ jobs:
       - name: ⛏️ Setup node
         uses: actions/setup-node@v3.4.1
         with:
-          node-version: '20.x'
+          node-version: '18.x'
           cache: 'pnpm'
 
       - name: 📚 Install workspace packages

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "Mono repository that holds the nuster project",
   "engines": {
-    "node": "20.x"
+    "node": "18.x"
   },
   "scripts": {
     "dev": "pnpm run dev:simulation & pnpm run dev:packages",

--- a/packages/simulation-server/Dockerfile
+++ b/packages/simulation-server/Dockerfile
@@ -1,5 +1,5 @@
 # Base image used by both steps
-FROM node:20-alpine AS base
+FROM node:18-alpine AS base
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"

--- a/packages/simulation-server/package.json
+++ b/packages/simulation-server/package.json
@@ -4,6 +4,9 @@
   "description": "Simulation tool server.",
   "main": "src/server.js",
   "private": true,
+  "engines": {
+    "node": "18.x"
+  },
   "scripts": {
     "build": "tsc",
     "dev": "tsx watch src/server.ts",
@@ -13,7 +16,7 @@
   "license": "UNLICENSED",
   "dependencies": {
     "cors": "^2.8.5",
-    "enip-ts": "1.2.2",
+    "enip-ts": "2.0.0",
     "express": "^4.19.2",
     "modbus-serial": "^8.0.16"
   },

--- a/packages/simulation-server/pnpm-lock.yaml
+++ b/packages/simulation-server/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^2.8.5
         version: 2.8.5
       enip-ts:
-        specifier: 1.2.2
-        version: 1.2.2
+        specifier: 2.0.0
+        version: 2.0.0
       express:
         specifier: ^4.19.2
         version: 4.19.2
@@ -354,8 +354,9 @@ packages:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
     engines: {node: '>= 0.8'}
 
-  enip-ts@1.2.2:
-    resolution: {integrity: sha512-IzHyHpz8jr/tIkOz18OTOcUP/0Pd7wuTVFHghcb7iR8I/bwH/A69wB8i4zy1NoctuuqEEEnbInDuJohSevyLNQ==}
+  enip-ts@2.0.0:
+    resolution: {integrity: sha512-gVmt4iMSAMV7Nx4AO7dWpNAazQCI9GFXD+em21GouKIpNYkMy9wBA9oP6RiSliA+QBT/rACHHeV7O3F+I6iTsg==}
+    engines: {node: ^20.x}
 
   es-define-property@1.0.0:
     resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
@@ -837,7 +838,7 @@ snapshots:
 
   encodeurl@1.0.2: {}
 
-  enip-ts@1.2.2: {}
+  enip-ts@2.0.0: {}
 
   es-define-property@1.0.0:
     dependencies:

--- a/packages/simulation-server/src/controllers/enip.ts
+++ b/packages/simulation-server/src/controllers/enip.ts
@@ -1,7 +1,6 @@
 import type { IOGates } from "@nuster/turbine/types/spec/iogates";
 import type { EX260Sx } from "@nuster/turbine/types/spec/iohandlers";
-import { ENIPServer } from "enip-ts/dist/enipServer";
-import { ENIPDataVector } from "enip-ts/dist/enipServer/enipClient";
+import { ENIPServer, ENIPDataVector } from "enip-ts/server";
 
 export class ENIPController
 {

--- a/packages/simulation-ui/package.json
+++ b/packages/simulation-ui/package.json
@@ -5,6 +5,9 @@
 	"private": true,
 	"type": "module",
 	"license": "UNLICENSED",
+	"engines": {
+		"node": "18.x"
+	},
 	"scripts": {
 		"dev": "vite dev --port 5174",
 		"build": "vite build",

--- a/packages/turbine/Dockerfile
+++ b/packages/turbine/Dockerfile
@@ -1,5 +1,5 @@
 # base image used by builder and production
-FROM node:20-alpine as base
+FROM node:18-alpine as base
 
 RUN corepack enable
 

--- a/packages/turbine/package.json
+++ b/packages/turbine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nuster/turbine",
   "engines": {
-    "node": "20.x"
+    "node": "18.x"
   },
   "version": "2.1.2",
   "description": "Handle complex machines cycles with ease using turbine.",
@@ -122,7 +122,7 @@
     "cookie-parser": "^1.4.6",
     "cors": "^2.8.5",
     "deep-extend": "^0.6.0",
-    "enip-ts": "1.2.2",
+    "enip-ts": "2.0.0",
     "express": "^4.19.2",
     "lockfile": "^1.0.4",
     "modbus-serial": "^8.0.16",

--- a/packages/turbine/pnpm-lock.yaml
+++ b/packages/turbine/pnpm-lock.yaml
@@ -30,8 +30,8 @@ importers:
         specifier: ^0.6.0
         version: 0.6.0
       enip-ts:
-        specifier: 1.2.2
-        version: 1.2.2
+        specifier: 2.0.0
+        version: 2.0.0
       express:
         specifier: ^4.19.2
         version: 4.19.2
@@ -895,8 +895,9 @@ packages:
   end-of-stream@1.4.4:
     resolution: {integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==}
 
-  enip-ts@1.2.2:
-    resolution: {integrity: sha512-IzHyHpz8jr/tIkOz18OTOcUP/0Pd7wuTVFHghcb7iR8I/bwH/A69wB8i4zy1NoctuuqEEEnbInDuJohSevyLNQ==}
+  enip-ts@2.0.0:
+    resolution: {integrity: sha512-gVmt4iMSAMV7Nx4AO7dWpNAazQCI9GFXD+em21GouKIpNYkMy9wBA9oP6RiSliA+QBT/rACHHeV7O3F+I6iTsg==}
+    engines: {node: ^20.x}
 
   es-define-property@1.0.0:
     resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
@@ -2672,7 +2673,7 @@ snapshots:
     dependencies:
       once: 1.4.0
 
-  enip-ts@1.2.2: {}
+  enip-ts@2.0.0: {}
 
   es-define-property@1.0.0:
     dependencies:

--- a/packages/ui/Dockerfile
+++ b/packages/ui/Dockerfile
@@ -1,5 +1,5 @@
 # base image used by builder and production
-FROM node:20-alpine as base
+FROM node:18-alpine as base
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -8,7 +8,7 @@
 	"author": "@metalizzsas/kworz",
 	"type": "module",
 	"engines": {
-		"node": "20.x"
+		"node": "18.x"
 	},
 	"scripts": {
 		"check": "svelte-check",


### PR DESCRIPTION
Node 20 made EthernetIP Controllers not work due to some changes on buffers.
Versions of turbine prior to this are unable to work with EthernetIP controllers.